### PR TITLE
Add and test CategoryService

### DIFF
--- a/src/main/java/org/iti/ecomus/exceptions/ConflictException.java
+++ b/src/main/java/org/iti/ecomus/exceptions/ConflictException.java
@@ -1,8 +1,9 @@
 package org.iti.ecomus.exceptions;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-// Thrown for violations like trying to create a resource that already exists
-// Adding user with existing email
+@ResponseStatus(HttpStatus.CONFLICT)
 public class ConflictException extends RuntimeException{
     public ConflictException(String message) {
         super(message);

--- a/src/main/java/org/iti/ecomus/exceptions/ResourceNotFoundException.java
+++ b/src/main/java/org/iti/ecomus/exceptions/ResourceNotFoundException.java
@@ -1,8 +1,11 @@
 package org.iti.ecomus.exceptions;
 
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 // This class represents a custom exception thrown when a requested resource is not found
+@ResponseStatus(HttpStatus.NOT_FOUND)
 public class ResourceNotFoundException extends RuntimeException {
     public ResourceNotFoundException(String message) {
         super(message);

--- a/src/main/java/org/iti/ecomus/mappers/CategoryMapper.java
+++ b/src/main/java/org/iti/ecomus/mappers/CategoryMapper.java
@@ -5,9 +5,13 @@ import org.iti.ecomus.dto.CategoryNoProductDTO;
 import org.iti.ecomus.entity.Category;
 import org.mapstruct.Mapper;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface CategoryMapper {
     CategoryDTO toCategoryDTO(Category category);
     CategoryNoProductDTO toCategoryNoProductDTO(Category category);
     Category toCategory(CategoryDTO categoryDTO);
+    List<CategoryDTO> toDtoList(List<Category> categories);
+    List<Category> toCategoryList(List<CategoryDTO> dtos);
 }

--- a/src/main/java/org/iti/ecomus/repository/CategoryRepo.java
+++ b/src/main/java/org/iti/ecomus/repository/CategoryRepo.java
@@ -4,15 +4,15 @@ import org.iti.ecomus.entity.Category;
 import org.springframework.data.jpa.repository.*;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
+import java.util.*;
 
 public interface CategoryRepo extends JpaRepository<Category, Long> {
 //
     @Query("SELECT c.categoryId FROM Category c WHERE c.categoryName IN :names")
-    List<Integer> findAllCategoryIdsByCategoryName(@Param("names") List<String> names);
-
+    List<Long> findAllCategoryIdsByCategoryName(@Param("names") List<String> names);
 
     Category getCategoryByCategoryName(String categoryName);
 
+    boolean existsCategoriesByCategoryName(String categoryName);
 
 }

--- a/src/main/java/org/iti/ecomus/service/impl/CategoryService.java
+++ b/src/main/java/org/iti/ecomus/service/impl/CategoryService.java
@@ -1,0 +1,112 @@
+package org.iti.ecomus.service.impl;
+
+import org.iti.ecomus.dto.CategoryDTO;
+import org.iti.ecomus.entity.Category;
+import org.iti.ecomus.exceptions.*;
+import org.iti.ecomus.mappers.CategoryMapper;
+import org.iti.ecomus.repository.CategoryRepo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class CategoryService {
+
+    @Autowired
+    CategoryRepo categoryRepo;
+
+    @Autowired
+    CategoryMapper categoryMapper;
+
+    @Transactional(readOnly = true)
+    public List<CategoryDTO> getAllCategories() {
+        return categoryRepo.findAll()
+                .stream()
+                .map(categoryMapper::toCategoryDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public CategoryDTO getCategoryById(Long categoryId) {
+        if (categoryId == null) {
+            throw new IllegalArgumentException("Category ID cannot be null");
+        }
+        return categoryRepo.findById(categoryId)
+                .map(categoryMapper::toCategoryDTO)
+                .orElseThrow(() ->
+                        new ResourceNotFoundException("Category not found with ID: " + categoryId));
+    }
+
+    public void addCategory(CategoryDTO dto) {
+        if (dto == null || dto.getCategoryName() == null || dto.getCategoryName().isBlank()) {
+            throw new IllegalArgumentException("Category name cannot be empty");
+        }
+        String trimmedName = dto.getCategoryName().trim();
+        if (isCategoryNameExists(trimmedName)) {
+            throw new ConflictException("Category name already exists");
+        }
+        Category category = categoryMapper.toCategory(dto);
+        category.setCategoryName(trimmedName);
+        categoryRepo.save(category);
+    }
+
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        if (categoryId == null) {
+            throw new IllegalArgumentException("Category ID cannot be null");
+        }
+
+        boolean exists = categoryRepo.existsById(categoryId);
+        if (!exists) {
+            throw new ResourceNotFoundException("Category with ID " + categoryId + " not found");
+        }
+
+        categoryRepo.deleteById(categoryId);
+    }
+
+
+    public void updateCategory(CategoryDTO dto) {
+
+        if (dto == null || dto.getCategoryId() == null) {
+            throw new IllegalArgumentException("Invalid data");
+        }
+
+        String trimmedName = dto.getCategoryName().trim();
+
+        if (trimmedName.isEmpty()) {
+            throw new IllegalArgumentException("Category name cannot be empty");
+        }
+
+        Category existing = categoryRepo.findById(dto.getCategoryId())
+                .orElseThrow(() -> new ResourceNotFoundException("Category not found"));
+
+        if (!existing.getCategoryName().equals(trimmedName)
+                && isCategoryNameExists(trimmedName)) {
+            throw new ConflictException("Category name already used");
+        }
+
+        Category updated = categoryMapper.toCategory(dto);
+        updated.setCategoryId(existing.getCategoryId());
+        updated.setCategoryName(trimmedName);
+        categoryRepo.save(updated);
+    }
+
+
+    public boolean isCategoryNameExists(String categoryName) {
+        return categoryRepo.existsCategoriesByCategoryName(categoryName);
+    }
+
+    @Transactional(readOnly = true)
+    public Long getCategoryIdByName(String categoryName) {
+        Category category = categoryRepo.getCategoryByCategoryName(categoryName);
+        if (category == null) {
+            throw new ResourceNotFoundException("Category not found with name: " + categoryName);
+        }
+        return category.getCategoryId();
+    }
+
+}

--- a/src/test/java/org/iti/ecomus/mapper/CategoryMapperTest.java
+++ b/src/test/java/org/iti/ecomus/mapper/CategoryMapperTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -91,6 +91,64 @@ public class CategoryMapperTest {
         assertEquals(1, productDTO.getCategories().size());
         assertEquals(1L, productDTO.getCategories().get(0).getCategoryId());
         assertEquals("ELECTRONICS", productDTO.getCategories().get(0).getCategoryName());
+    }
+
+    @Test
+    void testToCategoryDTOList() {
+        // Given
+        Category category1 = new Category();
+        category1.setCategoryId(1L);
+        category1.setCategoryName("ELECTRONICS");
+
+        Category category2 = new Category();
+        category2.setCategoryId(2L);
+        category2.setCategoryName("BOOKS");
+
+        List<Category> categories = Arrays.asList(category1, category2);
+
+        // When
+        List<CategoryDTO> dtos = categoryMapper.toDtoList(categories);
+
+        // Then
+        assertNotNull(dtos);
+        assertEquals(2, dtos.size());
+
+        CategoryDTO dto1 = dtos.get(0);
+        assertEquals(1L, dto1.getCategoryId());
+        assertEquals("ELECTRONICS", dto1.getCategoryName());
+
+        CategoryDTO dto2 = dtos.get(1);
+        assertEquals(2L, dto2.getCategoryId());
+        assertEquals("BOOKS", dto2.getCategoryName());
+    }
+
+    @Test
+    void testToCategoryEntityList() {
+        // Given
+        CategoryDTO dto1 = new CategoryDTO();
+        dto1.setCategoryId(10L);
+        dto1.setCategoryName("TOYS");
+
+        CategoryDTO dto2 = new CategoryDTO();
+        dto2.setCategoryId(20L);
+        dto2.setCategoryName("FURNITURE");
+
+        List<CategoryDTO> dtos = Arrays.asList(dto1, dto2);
+
+        // When
+        List<Category> entities = categoryMapper.toCategoryList(dtos);
+
+        // Then
+        assertNotNull(entities);
+        assertEquals(2, entities.size());
+
+        Category entity1 = entities.get(0);
+        assertEquals(10L, entity1.getCategoryId());
+        assertEquals("TOYS", entity1.getCategoryName());
+
+        Category entity2 = entities.get(1);
+        assertEquals(20L, entity2.getCategoryId());
+        assertEquals("FURNITURE", entity2.getCategoryName());
     }
 
 }

--- a/src/test/java/org/iti/ecomus/repository/AddressRepoTest.java
+++ b/src/test/java/org/iti/ecomus/repository/AddressRepoTest.java
@@ -4,54 +4,54 @@ import org.iti.ecomus.entity.Address;
 import org.iti.ecomus.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.List;
 
-import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
+@Transactional
 class AddressRepoTest {
 
+    @Autowired
     private AddressRepo addressRepo;
 
+    @Autowired
+    private UserRepo userRepo;
+
+    private User testUser;
+
     @BeforeEach
-    void setUp() {
-        addressRepo = mock(AddressRepo.class);
+    void setup() {
+        // Save test user with all required fields
+        testUser = new User();
+        testUser.setUserName("John Doe");
+        testUser.setEmail("john@example.com");
+        testUser.setPassword("123456");
+
+        userRepo.save(testUser);
+
+        // Save addresses
+        Address a1 = new Address();
+        a1.setArea("Downtown");
+        a1.setUser(testUser);
+
+        Address a2 = new Address();
+        a2.setArea("Suburb");
+        a2.setUser(testUser);
+
+        addressRepo.save(a1);
+        addressRepo.save(a2);
     }
 
     @Test
-    void testFindAddressByUserUserId() {
-        // Arrange
-        Long userId = 1L;
-
-        User user = new User();
-        user.setUserId(userId);
-        user.setUserName("John Doe");
-
-        Address address1 = new Address();
-        address1.setId(101L);
-        address1.setArea("Downtown");
-        address1.setUser(user);
-
-        Address address2 = new Address();
-        address2.setId(102L);
-        address2.setArea("Uptown");
-        address2.setUser(user);
-
-        List<Address> mockAddresses = List.of(address1, address2);
-
-        when(addressRepo.findAddressByUserUserId(userId)).thenReturn(mockAddresses);
-
-        // Act
-        List<Address> result = addressRepo.findAddressByUserUserId(userId);
-
-        // Assert
+    void testFindAddressByUserUserId_ReturnsCorrectAddresses() {
+        List<Address> result = addressRepo.findAddressByUserUserId(testUser.getUserId());
         assertEquals(2, result.size());
-        result.forEach(addr -> {
-            assertEquals(userId, addr.getUser().getUserId());
-            assertNotNull(addr.getArea());
-        });
-
-        verify(addressRepo, times(1)).findAddressByUserUserId(userId);
+        assertTrue(result.stream().anyMatch(a -> a.getArea().equals("Downtown")));
+        assertTrue(result.stream().anyMatch(a -> a.getArea().equals("Suburb")));
     }
 }

--- a/src/test/java/org/iti/ecomus/repository/CategoryRepoTest.java
+++ b/src/test/java/org/iti/ecomus/repository/CategoryRepoTest.java
@@ -3,53 +3,59 @@ package org.iti.ecomus.repository;
 import org.iti.ecomus.entity.Category;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.*;
+import java.util.List;
 
-import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-class CategoryRepoTest {
+@SpringBootTest
+@Transactional
+public class CategoryRepoTest {
 
+    @Autowired
     private CategoryRepo categoryRepo;
 
     @BeforeEach
     void setUp() {
-        categoryRepo = mock(CategoryRepo.class);
+        Category cat1 = new Category();
+        cat1.setCategoryName("Electronics1");
+
+        Category cat2 = new Category();
+        cat2.setCategoryName("Books1");
+
+        categoryRepo.save(cat1);
+        categoryRepo.save(cat2);
+    }
+
+    @Test
+    void testFindByName_ShouldReturnCorrectCategory() {
+        Category found = categoryRepo.getCategoryByCategoryName("Electronics1");
+        assertNotNull(found);
+        assertEquals("Electronics1", found.getCategoryName());
     }
 
     @Test
     void testFindAllCategoryIdsByCategoryName() {
         // Arrange
-        List<String> names = Arrays.asList("Electronics", "Books");
-        List<Integer> expectedIds = Arrays.asList(1, 2);
+        Category cat1 = new Category();
+        cat1.setCategoryName("Clothing1");
 
-        when(categoryRepo.findAllCategoryIdsByCategoryName(names)).thenReturn(expectedIds);
 
-        // Act
-        List<Integer> actualIds = categoryRepo.findAllCategoryIdsByCategoryName(names);
+        Category cat2 = new Category();
+        cat2.setCategoryName("Home1");
 
-        // Assert
-        assertEquals(expectedIds, actualIds);
-        verify(categoryRepo).findAllCategoryIdsByCategoryName(names);
-    }
-
-    @Test
-    void testGetCategoryByCategoryName() {
-        // Arrange
-        Category category = new Category();
-        category.setCategoryId(1L);
-        category.setCategoryName("Books");
-
-        when(categoryRepo.getCategoryByCategoryName("Books")).thenReturn(category);
+        categoryRepo.save(cat1);
+        categoryRepo.save(cat2);
 
         // Act
-        Category result = categoryRepo.getCategoryByCategoryName("Books");
+        List<Long> ids = categoryRepo.findAllCategoryIdsByCategoryName(List.of("Clothing1", "Home1"));
 
         // Assert
-        assertNotNull(result);
-        assertEquals("Books", result.getCategoryName());
-        assertEquals(1, result.getCategoryId());
-        verify(categoryRepo).getCategoryByCategoryName("Books");
+        assertEquals(2, ids.size());
+        assertTrue(ids.contains(cat1.getCategoryId()));
+        assertTrue(ids.contains(cat2.getCategoryId()));
     }
 }

--- a/src/test/java/org/iti/ecomus/service/CategoryServiceTest.java
+++ b/src/test/java/org/iti/ecomus/service/CategoryServiceTest.java
@@ -1,0 +1,238 @@
+package org.iti.ecomus.service;
+
+import org.iti.ecomus.dto.CategoryDTO;
+import org.iti.ecomus.entity.Category;
+import org.iti.ecomus.exceptions.ConflictException;
+import org.iti.ecomus.exceptions.ResourceNotFoundException;
+import org.iti.ecomus.mappers.CategoryMapper;
+import org.iti.ecomus.repository.CategoryRepo;
+import org.iti.ecomus.service.impl.CategoryService;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class CategoryServiceTest {
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private CategoryRepo categoryRepo;
+
+    @Autowired
+    private CategoryMapper categoryMapper;
+
+    private Category category;
+
+    private String generateUniqueName(String base) {
+        return base + "_" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    @BeforeEach
+    void setUp() {
+        String name = generateUniqueName("Electronics");
+        category = new Category();
+        category.setCategoryName(name);
+        category = categoryRepo.save(category);
+    }
+
+    // -----------------------------
+    @Nested
+    class GetAllCategoriesTests {
+
+        @Test
+        void testGetAllCategories() {
+            List<CategoryDTO> categories = categoryService.getAllCategories();
+            assertFalse(categories.isEmpty());
+        }
+    }
+
+    // -----------------------------
+    @Nested
+    class GetCategoryByIdTests {
+
+        @Test
+        void testGetCategoryById_ValidId() {
+            CategoryDTO dto = categoryService.getCategoryById(category.getCategoryId());
+            assertNotNull(dto);
+            assertEquals(category.getCategoryName(), dto.getCategoryName());
+        }
+
+        @Test
+        void testGetCategoryById_NotValid() {
+            assertThrows(ResourceNotFoundException.class, () -> categoryService.getCategoryById(999999L));
+        }
+
+        @Test
+        void testGetCategoryById_NullIdThrowsException() {
+            assertThrows(IllegalArgumentException.class, () -> categoryService.getCategoryById(null));
+        }
+    }
+
+    // -----------------------------
+    @Nested
+    class AddCategoryTests {
+
+        @Test
+        void testAddCategory_Success() {
+            CategoryDTO dto = new CategoryDTO();
+            dto.setCategoryName(generateUniqueName("Books"));
+            categoryService.addCategory(dto);
+
+            assertTrue(categoryRepo.existsCategoriesByCategoryName(dto.getCategoryName()));
+        }
+
+        @Test
+        void testAddCategory_NullDto_ThrowsException() {
+            assertThrows(IllegalArgumentException.class, () -> categoryService.addCategory(null));
+        }
+
+        @Test
+        void testAddCategory_NullName_ThrowsException() {
+            CategoryDTO dto = new CategoryDTO();
+            dto.setCategoryName(null);
+            assertThrows(IllegalArgumentException.class, () -> categoryService.addCategory(dto));
+        }
+
+        @Test
+        void testAddCategory_BlankName_ThrowsException() {
+            CategoryDTO dto = new CategoryDTO();
+            dto.setCategoryName("   ");
+            assertThrows(IllegalArgumentException.class, () -> categoryService.addCategory(dto));
+        }
+
+        @Test
+        void testAddCategory_DuplicateNameThrowsException() {
+            CategoryDTO dto = new CategoryDTO();
+            dto.setCategoryName(category.getCategoryName());
+            assertThrows(ConflictException.class, () -> categoryService.addCategory(dto));
+        }
+    }
+
+    // -----------------------------
+    @Nested
+    class UpdateCategoryTests {
+
+        @Test
+        void testUpdateCategory_NullDto_ThrowsException() {
+            assertThrows(IllegalArgumentException.class, () -> categoryService.updateCategory(null));
+        }
+
+        @Test
+        void testUpdateCategory_NullId_ThrowsException() {
+            CategoryDTO dto = new CategoryDTO();
+            dto.setCategoryId(null);
+            dto.setCategoryName("ValidName");
+            assertThrows(IllegalArgumentException.class, () -> categoryService.updateCategory(dto));
+        }
+
+        @Test
+        void testUpdateCategory_BlankName_ThrowsException() {
+            CategoryDTO dto = new CategoryDTO();
+            dto.setCategoryId(category.getCategoryId());
+            dto.setCategoryName("   ");
+            assertThrows(IllegalArgumentException.class, () -> categoryService.updateCategory(dto));
+        }
+
+        @Test
+        void testUpdateCategory_CategoryNotFound_ThrowsException() {
+            CategoryDTO dto = new CategoryDTO();
+            dto.setCategoryId(999999L);
+            dto.setCategoryName("UpdatedName");
+            assertThrows(ResourceNotFoundException.class, () -> categoryService.updateCategory(dto));
+        }
+
+        @Test
+        void testUpdateCategory_DuplicateName_ThrowsException() {
+            String duplicateName = generateUniqueName("Duplicate");
+            Category other = new Category();
+            other.setCategoryName(duplicateName);
+            categoryRepo.save(other);
+
+            CategoryDTO dto = categoryMapper.toCategoryDTO(category);
+            dto.setCategoryName(duplicateName);
+            assertThrows(ConflictException.class, () -> categoryService.updateCategory(dto));
+        }
+
+        @Test
+        void testUpdateCategory_Success() {
+            CategoryDTO dto = categoryMapper.toCategoryDTO(category);
+            String updatedName = generateUniqueName("Updated");
+            dto.setCategoryName(updatedName);
+
+            categoryService.updateCategory(dto);
+
+            Category updated = categoryRepo.findById(dto.getCategoryId()).orElse(null);
+            assertNotNull(updated);
+            assertEquals(updatedName, updated.getCategoryName());
+        }
+
+        @Test
+        void testUpdateCategory_WithSameName_NoConflict() {
+            CategoryDTO dto = categoryMapper.toCategoryDTO(category);
+            assertDoesNotThrow(() -> categoryService.updateCategory(dto));
+        }
+    }
+
+    // -----------------------------
+    @Nested
+    class DeleteCategoryTests {
+
+        @Test
+        void testDeleteCategory_Success() {
+            categoryService.deleteCategory(category.getCategoryId());
+            assertFalse(categoryRepo.existsById(category.getCategoryId()));
+        }
+
+        @Test
+        void testDeleteCategory_NotExistThrows() {
+            assertThrows(ResourceNotFoundException.class, () -> categoryService.deleteCategory(999L));
+        }
+    }
+
+    // -----------------------------
+    @Nested
+    class GetCategoryIdByNameTests {
+
+        @Test
+        void testGetCategoryIdByName_Valid() {
+            Long id = categoryService.getCategoryIdByName(category.getCategoryName());
+            assertEquals(category.getCategoryId(), id);
+        }
+
+        @Test
+        void testGetCategoryIdByName_NotFoundThrows() {
+            String randomName = generateUniqueName("NonExisting");
+            assertThrows(ResourceNotFoundException.class, () -> categoryService.getCategoryIdByName(randomName));
+        }
+    }
+
+    // -----------------------------
+    @Nested
+    class IsCategoryNameExistsTests {
+
+        @Test
+        void testIsCategoryNameExists_True() {
+            String existingName = generateUniqueName("Existing");
+            Category cat = new Category();
+            cat.setCategoryName(existingName);
+            categoryRepo.save(cat);
+
+            assertTrue(categoryService.isCategoryNameExists(existingName));
+        }
+
+        @Test
+        void testIsCategoryNameExists_False() {
+            String nonExistingName = generateUniqueName("NonExisting");
+            assertFalse(categoryService.isCategoryNameExists(nonExistingName));
+        }
+    }
+}


### PR DESCRIPTION
- Added @ResponseStatus annotations to:
  - ConflictException (@HttpStatus.CONFLICT)
  - ResourceNotFoundException (@HttpStatus.NOT_FOUND)

- Extended CategoryRepo with:
  - existsCategoriesByCategoryName(String name)

- Created CategoryService:
  - Implemented core CRUD operations
  - Integrated validation and conflict checks
  - Fully covered with integration tests

- Enhanced CategoryMapper with:
  - toDtoList(List<Category>)
  - toCategoryList(List<CategoryDTO>)
  - Updated and extended corresponding test class

- Refactored:
  - AddressRepoTest for direct DB interaction
  - CategoryRepoTest for improved structure and clarity