### PR TITLE
Removes unnecessary @Repository annotation

### DIFF
--- a/src/main/java/org/iti/ecomus/service/ProductCategoryService.java
+++ b/src/main/java/org/iti/ecomus/service/ProductCategoryService.java
@@ -2,7 +2,7 @@ package org.iti.ecomus.service;
 
 import org.springframework.stereotype.Repository;
 
-@Repository
+//@Repository
 public interface ProductCategoryService {
 
 }

--- a/src/main/java/org/iti/ecomus/service/ProductService.java
+++ b/src/main/java/org/iti/ecomus/service/ProductService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
-@Repository
+//@Repository
 public interface ProductService {
 
 


### PR DESCRIPTION
Removes the @Repository annotation from the ProductCategoryService and ProductService interfaces.

These annotations are not needed on interfaces, as they are typically used to mark concrete classes as Spring-managed repositories.