### PR TITLE
Configures User entity for caching

### DIFF
--- a/src/main/java/org/iti/ecomus/dto/UserDTO.java
+++ b/src/main/java/org/iti/ecomus/dto/UserDTO.java
@@ -26,7 +26,7 @@ public class UserDTO {
 
     private String email;
 
-    private String password;
+//    private String password;
 
     private Date BD;
 

--- a/src/main/java/org/iti/ecomus/entity/User.java
+++ b/src/main/java/org/iti/ecomus/entity/User.java
@@ -25,6 +25,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 @EqualsAndHashCode
 @ToString(exclude = {"addresses", "orders", "carts"})
 @NamedQuery(query = "SELECT u FROM User u WHERE u.userName = :userName", name = "User.findByUserName")
+@Cacheable
+@org.hibernate.annotations.Cache(usage = org.hibernate.annotations.CacheConcurrencyStrategy.READ_WRITE)
 public class User implements Serializable, UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/iti/ecomus/util/validation/OnProfile.java
+++ b/src/main/java/org/iti/ecomus/util/validation/OnProfile.java
@@ -1,0 +1,4 @@
+package org.iti.ecomus.util.validation;
+
+public interface OnProfile {
+}


### PR DESCRIPTION
Configures the User entity to use Hibernate's second-level cache
with a read-write concurrency strategy to improve performance.
Removes password from DTO to enhance security.
Introduces marker interface for validation grouping.
